### PR TITLE
PatinaPkg: Add measurement bit note in PatinaPerformanceConfig.h

### DIFF
--- a/PatinaPkg/Include/Guid/PatinaPerformanceConfig.h
+++ b/PatinaPkg/Include/Guid/PatinaPerformanceConfig.h
@@ -18,7 +18,7 @@
         component. For example, the platform may choose to populate the HOB values based on a build flag, a PCD, or
         other mechanism for the given platform build/boot.
 
-  Copyright (c) Microsoft Corporation. All rights reserved.
+  Copyright (c) Microsoft Corporation.
 
   SPDX-License-Identifier: Apache-2.0
 
@@ -38,6 +38,11 @@ typedef struct {
   BOOLEAN    Enabled;
   ///
   /// A mask for selecting measurements enabled in the Patina Performance component.
+  ///
+  /// See the Patina Performance Component for the most recent configuration details
+  /// including measurement bit definitions:
+  ///
+  /// https://github.com/OpenDevicePartnership/patina/tree/main/components/patina_performance
   ///
   UINT32     EnabledMeasurements;
 } PATINA_PERFORMANCE_CONFIG_HOB;


### PR DESCRIPTION
Adds a note that points to the Patina Performance component readme to show how bits are configured in the measurement mask.

The actual enum definitions is in the `patina` crate, however, the Patina Performance config definition is more relevant here and might track movement of that enum in the future to a different location.

The Microsoft open-source copyright does not have the text "All rights reserved" included so that is fixed. This is the only file in the repo found to have that text, so the update is simply included in this commit.